### PR TITLE
Added .ts extensions to imports

### DIFF
--- a/dinatra.ts
+++ b/dinatra.ts
@@ -1,8 +1,8 @@
 import { serve } from 'https://deno.land/x/net/http.ts';
-import { Response, processResponse } from './response';
-import { ErrorCode, getErrorMessage } from './errors';
-import { Method, Params, Context, Handler, HandlerConfig } from './handler';
-export { get, post, put, patch, del, options, link, unlink } from './handler';
+import { Response, processResponse } from './response.ts';
+import { ErrorCode, getErrorMessage } from './errors.ts';
+import { Method, Params, Context, Handler, HandlerConfig } from './handler.ts';
+export { get, post, put, patch, del, options, link, unlink } from './handler.ts';
 
 const defaultPort = '8080';
 

--- a/handler.ts
+++ b/handler.ts
@@ -1,4 +1,4 @@
-import { Response } from './response';
+import { Response } from './response.ts';
 
 export enum Method {
   GET = 'GET',


### PR DESCRIPTION
I got this error:

```
Downloading https://syumai.github.io/dinatra/response... NOT FOUND
NotFound: Cannot resolve module "./response" from "home/.deno/deps/https/syumai.github.io/dinatra/dinatra.ts"
```

I found that latest deno needs "ts" extension in import.

```
import { Response, processResponse } from './response';
```

Fixed: 

```
import { Response, processResponse } from './response.ts';
```