### PR TITLE
Add AsyncHandler and support Reader as response body

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,21 +58,58 @@ deno index.ts -p 8000 # or --port 8000
 # App runs on localhost:8000
 ```
 
-## Response Types
+## Reponse Types
 
 ```ts
-export type Response =
-  | StatusHeadersBodyResponse
-  | StatusBodyResponse
-  | number // HTTP status code only
-  | string; // Response body only
-
-type StatusHeadersBodyResponse = [number, HeaderMap, string];
-type StatusBodyResponse = [number, string];
-
+// HeaderMap is a type of response headers.
 type HeaderMap =
   | Headers
   | {
       [key: string]: any;
     };
+
+// ResponseBody is a type of response body.
+type ResponseBody = string | Reader;
+
+/*
+ *  Types of Response
+ */
+
+// StatusHeadersBodyResponse is a response with status code, headers, body.
+type StatusHeadersBodyResponse = [number, HeaderMap, ResponseBody];
+
+// StatusBodyResponse is a response with status code, body.
+type StatusBodyResponse = [number, ResponseBody];
+
+// Response is a type of response.
+export type Response =
+  | StatusHeadersBodyResponse
+  | StatusBodyResponse
+  | number // HTTP status code only
+  | ResponseBody; // Response body only
+
+// Response interface of deno.land/x/net/http
+interface HTTPResponse {
+  status?: number;
+  headers?: Headers;
+  body?: Uint8Array | Reader;
+}
+```
+
+## Advanced
+
+### Async Handler
+
+- You can use async function as handler.
+
+`example/template/index.ts`
+
+```ts
+import { app, get, post } from '../../dinatra.ts';
+import { cwd, open } from 'deno';
+
+const currentDir = cwd();
+const htmlPath = `${currentDir}/index.html`;
+
+app(get('/', async () => await open(htmlPath)));
 ```

--- a/dinatra.ts
+++ b/dinatra.ts
@@ -1,7 +1,7 @@
 import { serve } from 'https://deno.land/x/net/http.ts';
 import { Response, processResponse } from './response.ts';
 import { ErrorCode, getErrorMessage } from './errors.ts';
-import { Method, Params, Context, Handler, HandlerConfig } from './handler.ts';
+import { Method, Params, Handler, HandlerConfig } from './handler.ts';
 import { defaultPort } from './constants.ts';
 export {
   get,
@@ -47,7 +47,7 @@ export class App {
         const method = req.method as Method;
         let res: Response;
         try {
-          res = ((): Response => {
+          res = await ((): Promise<Response> => {
             if (!req.url) {
               throw ErrorCode.NotFound;
             }
@@ -73,7 +73,11 @@ export class App {
             }
 
             const ctx = { path, method, params };
-            return handler(ctx);
+            const result = handler(ctx);
+            if (result instanceof Promise) {
+              return result;
+            }
+            return Promise.resolve(result);
           })();
         } catch (err) {
           res = ((): Response => {

--- a/example/template/index.html
+++ b/example/template/index.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Template example</title>
+  </head>
+  <body>
+    <h1>Hello, world!</h1>
+  </body>
+</html>

--- a/example/template/index.ts
+++ b/example/template/index.ts
@@ -1,0 +1,7 @@
+import { app, get, post } from '../../dinatra.ts';
+import { cwd, open } from 'deno';
+
+const currentDir = cwd();
+const htmlPath = `${currentDir}/index.html`;
+
+app(get('/', async () => await open(htmlPath)));

--- a/handler.ts
+++ b/handler.ts
@@ -21,8 +21,14 @@ export type Context = {
   params?: Params;
 };
 
-export interface Handler {
+export type Handler = BasicHandler | AsyncHandler;
+
+export interface BasicHandler {
   (ctx?: Context): Response;
+}
+
+export interface AsyncHandler {
+  (ctx?: Context): Promise<Response>;
 }
 
 export type HandlerConfig = {


### PR DESCRIPTION
## What

* Added async handler.
  - This enables using async function as handler.
* Supported Reader as response body.
  - This enables streaming response body instead of read all of them into memory.

## Example

```ts
import { app, get, post } from '../../dinatra.ts';
import { cwd, open } from 'deno';

const currentDir = cwd();
const htmlPath = `${currentDir}/index.html`;

app(get('/', async () => await open(htmlPath)));
```