### PR TITLE
Removed python from travis CI config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
-language: python
+language: minimal
 
 install:
-  - curl -L https://deno.land/x/install/install.py | python
+  - curl -L https://deno.land/x/install/install.sh | bash
   - export PATH="$HOME/.deno/bin:$PATH"
 
 script:

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
 .PHONY: test
 
 test:
-	deno static_test.ts --allow-net
+	deno static_test.ts --allow-net --allow-read


### PR DESCRIPTION
## What

* Same as title.

## Why

* Because installation script has been updated not to require python.