### PR TITLE
Add std to module paths

### DIFF
--- a/constants.ts
+++ b/constants.ts
@@ -1,5 +1,5 @@
 import { args } from 'deno';
-import { parse } from 'https://deno.land/x/flags/mod.ts';
+import { parse } from 'https://deno.land/x/std/flags/mod.ts';
 
 export const parsedArgs: {
   p?: string;

--- a/mod.ts
+++ b/mod.ts
@@ -1,4 +1,7 @@
-import { listenAndServe, ServerRequest } from 'https://deno.land/x/http/server.ts';
+import {
+  listenAndServe,
+  ServerRequest,
+} from 'https://deno.land/x/std/http/server.ts';
 import { stat, FileInfo, open } from 'deno';
 import { Response, processResponse } from './response.ts';
 import { ErrorCode, getErrorMessage } from './errors.ts';

--- a/static_test.ts
+++ b/static_test.ts
@@ -1,4 +1,4 @@
-import { test, runTests } from 'https://deno.land/x/testing/mod.ts';
+import { test, runTests } from 'https://deno.land/x/std/testing/mod.ts';
 import { assertEqual } from 'https://deno.land/x/pretty_assert@0.1.5/mod.ts';
 import { exit } from 'deno';
 import { App } from './mod.ts';


### PR DESCRIPTION
## What

* Add `std` to module import path.

## Why

* Because `strings` is not included to registry yet.