### PR TITLE
Fix space decoding in form params

### DIFF
--- a/handler.ts
+++ b/handler.ts
@@ -1,4 +1,5 @@
 import { Response } from './response.ts';
+import { Params } from './params.ts';
 
 export enum Method {
   GET = 'GET',
@@ -9,10 +10,6 @@ export enum Method {
   OPTIONS = 'OPTIONS',
   LINK = 'LINK',
   UNLINK = 'UNLINK',
-}
-
-export interface Params {
-  [key: string]: any;
 }
 
 export type Context = {

--- a/params.ts
+++ b/params.ts
@@ -1,0 +1,12 @@
+export interface Params {
+  [key: string]: any;
+}
+
+export function parseURLSearchParams(paramsStr: string): Params {
+  const params: Params = {};
+  const spaceReplacedStr = paramsStr.replace(/\+/g, ' '); // replace all + to spaces
+  for (const [key, value] of new URLSearchParams(spaceReplacedStr).entries()) {
+    params[key] = value;
+  }
+  return params;
+}

--- a/serve_test.ts
+++ b/serve_test.ts
@@ -1,7 +1,7 @@
 import { test, runTests } from 'https://deno.land/std/testing/mod.ts';
 import { assertEquals } from 'https://deno.land/std/testing/asserts.ts';
 import { App, get, post } from './mod.ts';
-import { HandlerConfig, Method, Params } from './handler.ts';
+import { HandlerConfig, Method } from './handler.ts';
 const { exit } = Deno;
 
 const sleep = (ms: number) => new Promise(r => setTimeout(r, ms));


### PR DESCRIPTION
## What

* Same as title.
* Moved Params from handler.ts to params.ts.
* Changed to output unhandled error into stderr.