### PR TITLE
Support content-type with parameters

### DIFF
--- a/mod.ts
+++ b/mod.ts
@@ -124,7 +124,7 @@ export class App {
           Object.assign(params, obj);
           break;
         case 'application/octet-stream':
-          params['data'] = decodedBody
+          // FIXME: we skip here for now, it should be implemented when Issue #41 resolved.
           break;
       }
     }

--- a/mod.ts
+++ b/mod.ts
@@ -100,7 +100,7 @@ export class App {
       }
     } else {
       const rawContentType = req.headers.get('content-type') || "application/octet-stream";
-      const [contentType, ...typeParamsArray] = rawContentType.split(';')
+      const [contentType, ...typeParamsArray] = rawContentType.split(';').map(s => s.trim());
       const typeParams = Object.assign({}, ...typeParamsArray.map(params => params.split('=')))
 
       const decoder = new TextDecoder(typeParams['charset'] || "utf-8")

--- a/mod.ts
+++ b/mod.ts
@@ -101,7 +101,11 @@ export class App {
     } else {
       const rawContentType = req.headers.get('content-type') || "application/octet-stream";
       const [contentType, ...typeParamsArray] = rawContentType.split(';').map(s => s.trim());
-      const typeParams = Object.assign({}, ...typeParamsArray.map(params => params.split('=')))
+      const typeParams = typeParamsArray.reduce((params, curr) => {
+        const [key, value] = curr.split('=');
+        params[key] = value;
+        return params;
+      }, {});
 
       const decoder = new TextDecoder(typeParams['charset'] || "utf-8"); // TODO: downcase `charset` key
       const decodedBody = decoder.decode(await readAll(req.body)); // FIXME: this line is should be refactored using Deno.Reader

--- a/mod.ts
+++ b/mod.ts
@@ -103,7 +103,7 @@ export class App {
       const [contentType, ...typeParamsArray] = rawContentType.split(';').map(s => s.trim());
       const typeParams = Object.assign({}, ...typeParamsArray.map(params => params.split('=')))
 
-      const decoder = new TextDecoder(typeParams['charset'] || "utf-8")
+      const decoder = new TextDecoder(typeParams['charset'] || "utf-8"); // TODO: downcase `charset` key
       const decodedBody = decoder.decode(await readAll(req.body)); // FIXME: this line is should be refactored using Deno.Reader
 
       switch (contentType) {

--- a/serve_test.ts
+++ b/serve_test.ts
@@ -23,6 +23,7 @@ interface testCase {
   path: string;
   method: Method;
   params?: string | FormData;
+  headers?: Record<string, string>;
   expected: string;
 }
 
@@ -48,6 +49,23 @@ const testCases: Array<testCase> = [
     method: Method.GET,
     expected: 'john',
   },
+  {
+    name: 'valid post',
+    registered: post('/params', ({ params }) => [200, params.name]),
+    path: 'params',
+    params: JSON.stringify({ name: 'ben' }),
+    method: Method.POST,
+    expected: 'ben'
+  },
+  {
+    name: 'valid post with detailed content-type',
+    registered: post('/params', ({ params }) => [200, params.name]),
+    path: 'params',
+    params: JSON.stringify({ name: 'tom' }),
+    headers: {['content-type']: 'application/json; charset=utf-8'},
+    method: Method.POST,
+    expected: 'tom'
+  }
   // this test doesn't pass because deno's fetch is broken.
   // {
   //   name: 'valid post formdata',
@@ -79,7 +97,7 @@ for (const tc of testCases) {
       const reqInit: RequestInit = { method: tc.method };
       if (typeof tc.params === 'string') {
         reqInit.body = tc.params;
-        reqInit.headers = { 'content-type': 'application/json' };
+        reqInit.headers = Object.assign({ 'content-type': 'application/json' }, tc.headers);
       } else {
         reqInit.body = tc.params;
       }

--- a/serve_test.ts
+++ b/serve_test.ts
@@ -62,7 +62,7 @@ const testCases: Array<testCase> = [
     registered: post('/params', ({ params }) => [200, params.name]),
     path: 'params',
     params: JSON.stringify({ name: 'tom' }),
-    headers: {['content-type']: 'application/json; charset=utf-8'},
+    headers: { 'content-type': 'application/json; charset=utf-8' },
     method: Method.POST,
     expected: 'tom'
   }
@@ -97,7 +97,7 @@ for (const tc of testCases) {
       const reqInit: RequestInit = { method: tc.method };
       if (typeof tc.params === 'string') {
         reqInit.body = tc.params;
-        reqInit.headers = Object.assign({ 'content-type': 'application/json' }, tc.headers);
+        reqInit.headers = tc.headers || { 'content-type': 'application/json' };
       } else {
         reqInit.body = tc.params;
       }


### PR DESCRIPTION
A current code can't process HTTP request included content-type with parameters such as `application/json;charset=utf-8`.
This PR resolve it, also, define default behaviour when content-type isn't set.
According to RFC2616, we should treat unknown content-type data as "application/octet-stream".

ref: https://www.w3.org/Protocols/rfc2616/rfc2616-sec7.html