### PR TITLE
Update Deno to v0.34.0

### DIFF
--- a/dem.json
+++ b/dem.json
@@ -4,7 +4,7 @@
     {
       "protocol": "https",
       "path": "deno.land/std",
-      "version": "v0.23.0",
+      "version": "v0.34.0",
       "files": [
         "/flags/mod.ts",
         "/http/server.ts",

--- a/dem.json
+++ b/dem.json
@@ -9,8 +9,7 @@
         "/flags/mod.ts",
         "/http/server.ts",
         "/strings/mod.ts",
-        "/testing/asserts.ts",
-        "/testing/mod.ts"
+        "/testing/asserts.ts"
       ]
     }
   ]

--- a/handler.ts
+++ b/handler.ts
@@ -15,17 +15,17 @@ export enum Method {
 export type Context = {
   readonly path: string;
   readonly method: Method;
-  params?: Params;
+  params: Params;
 };
 
 export type Handler = BasicHandler | AsyncHandler;
 
 export interface BasicHandler {
-  (ctx?: Context): Response;
+  (ctx: Context): Response;
 }
 
 export interface AsyncHandler {
-  (ctx?: Context): Promise<Response>;
+  (ctx: Context): Promise<Response>;
 }
 
 export type HandlerConfig = {

--- a/serve_test.ts
+++ b/serve_test.ts
@@ -1,8 +1,7 @@
-import { test, runTests } from './vendor/https/deno.land/std/testing/mod.ts';
 import { assertEquals } from './vendor/https/deno.land/std/testing/asserts.ts';
 import { App, get, post } from './mod.ts';
 import { HandlerConfig, Method } from './handler.ts';
-const { exit } = Deno;
+const { exit, test, runTests } = Deno;
 
 const sleep = (ms: number) => new Promise(r => setTimeout(r, ms));
 
@@ -94,7 +93,7 @@ const testCases: Array<testCase> = [
   },
   {
     name: 'valid post with detailed content-type',
-    registered: post('/params', ({ params }) => [200, params.name]),
+    registered: post('/params', ({ params }) => [200, params!.name]),
     path: 'params',
     params: JSON.stringify({ name: 'tom' }),
     headers: { 'content-type': 'application/json; charset=utf-8' },

--- a/static_test.ts
+++ b/static_test.ts
@@ -1,7 +1,6 @@
-import { test, runTests } from './vendor/https/deno.land/std/testing/mod.ts';
 import { assertEquals } from './vendor/https/deno.land/std/testing/asserts.ts';
 import { App } from './mod.ts';
-const { exit } = Deno;
+const { exit, test, runTests } = Deno;
 
 const testPort = 8376;
 const host = `http://localhost:${testPort}`;

--- a/vendor/https/deno.land/std/flags/mod.ts
+++ b/vendor/https/deno.land/std/flags/mod.ts
@@ -1,1 +1,1 @@
-export * from 'https://deno.land/std@v0.23.0/flags/mod.ts';
+export * from 'https://deno.land/std@v0.34.0/flags/mod.ts';

--- a/vendor/https/deno.land/std/http/server.ts
+++ b/vendor/https/deno.land/std/http/server.ts
@@ -1,1 +1,1 @@
-export * from 'https://deno.land/std@v0.23.0/http/server.ts';
+export * from 'https://deno.land/std@v0.34.0/http/server.ts';

--- a/vendor/https/deno.land/std/strings/mod.ts
+++ b/vendor/https/deno.land/std/strings/mod.ts
@@ -1,1 +1,1 @@
-export * from 'https://deno.land/std@v0.23.0/strings/mod.ts';
+export * from 'https://deno.land/std@v0.34.0/strings/mod.ts';

--- a/vendor/https/deno.land/std/testing/asserts.ts
+++ b/vendor/https/deno.land/std/testing/asserts.ts
@@ -1,1 +1,1 @@
-export * from 'https://deno.land/std@v0.23.0/testing/asserts.ts';
+export * from 'https://deno.land/std@v0.34.0/testing/asserts.ts';

--- a/vendor/https/deno.land/std/testing/mod.ts
+++ b/vendor/https/deno.land/std/testing/mod.ts
@@ -1,1 +1,0 @@
-export * from 'https://deno.land/std@v0.34.0/testing/mod.ts';

--- a/vendor/https/deno.land/std/testing/mod.ts
+++ b/vendor/https/deno.land/std/testing/mod.ts
@@ -1,1 +1,1 @@
-export * from 'https://deno.land/std@v0.23.0/testing/mod.ts';
+export * from 'https://deno.land/std@v0.34.0/testing/mod.ts';


### PR DESCRIPTION
- TS strict mode has been enabled by default since Deno v0.34.0.
- The test runner has been bundled into Deno and `std/testing/mod.ts` has been removed since v0.33.0.
- `ServerRequest.body` has been changed from a function that returns `Promise<Uint8Array>` to `Reader` since v0.28.1.
  - https://github.com/denoland/deno/pull/3575