### PR TITLE
Specified the need for allow-read when serving static files

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,7 @@ app(
 
 ### Host static files
 
+- Requires `--allow-read`, e.g. `deno run --allow-read --allow-net app.ts`
 - Files in `./public` directory will be served static.
 
 ### Close server


### PR DESCRIPTION
Hi! 

Although obvious in retrospect, I did not realize that i had to `--allow-read` to make static file serving work. I am proposing to add this info to `README.md`. Alternatively (additionally?), it would be nice if Dinatra warned the user about it, e.g.: 
```ts
catch (e) {
      if(e.name === "PermissionDenied") {
           console.log("Run with --allow-read to serve static files");
      }
}
```
at: https://github.com/syumai/dinatra/blob/master/mod.ts#L55
