### PR TITLE
Ensure that test failures are reported correctly

### DIFF
--- a/serve_test.ts
+++ b/serve_test.ts
@@ -133,12 +133,12 @@ for (const tc of testCases) {
       const actual = await res.text();
       const contentLength = res.headers.get("content-length");
 
-      assertEquals(actual, tc.expected);
-      assertEquals(contentLength, tc.expected.length.toString());
-
       const { path, method } = tc.registered;
       app.unregister(path, method);
       app.close();
+
+      assertEquals(actual, tc.expected);
+      assertEquals(contentLength, tc.expected.length.toString());
     },
   });
 }

--- a/static_test.ts
+++ b/static_test.ts
@@ -53,10 +53,11 @@ for (const tc of testCases) {
       const res = await fetch(`${host}/${tc.path}`);
       const actual = await res.text();
       const contentLength = res.headers.get("content-length");
-      assertEquals(actual, tc.expected);
-      assertEquals(contentLength, tc.expected.length.toString());
 
       app.close();
+
+      assertEquals(actual, tc.expected);
+      assertEquals(contentLength, tc.expected.length.toString());
     },
   });
 }


### PR DESCRIPTION
Before this change if one of the tests failed an AddrInUse exception was
raised and the details of the test failure would be lost.

For example:

```
...
test valid index path ... listening on http://0.0.0.0:8376/
FAILED (5ms)
test valid nested normal path ... error: Uncaught AddrInUse: Address already in use (os error 48)
    at unwrapResponse ($deno$/ops/dispatch_json.ts:43:11)
    at Object.sendSync ($deno$/ops/dispatch_json.ts:72:10)
    at Object.listen ($deno$/ops/net.ts:51:10)
    at listen ($deno$/net.ts:152:22)
    at App.serve (file:///localpath/dinatra/mod.ts:196:22)
    at fn (file:///localpath/dinatra/static_test.ts:51:11)
    at asyncOpSanitizer ($deno$/testing.ts:36:11)
    at Object.resourceSanitizer [as fn] ($deno$/testing.ts:70:11)
    at TestApi.[Symbol.asyncIterator] ($deno$/testing.ts:264:22)
    at TestApi.next (<anonymous>)
make: *** [test] Error 1
```

After this change the test failure can be seen

```
failures:

valid index path
AssertionError:

    [Diff] Actual / Expected

-   "not found"
+   "ok"

    at assertEquals (https://deno.land/std@v0.51.0/testing/asserts.ts:166:9)
    at fn (file:///localpath/dinatra/static_test.ts:59:7)
    at async asyncOpSanitizer ($deno$/testing.ts:36:5)
    at async Object.resourceSanitizer [as fn] ($deno$/testing.ts:70:5)
    at async TestApi.[Symbol.asyncIterator] ($deno$/testing.ts:264:11)
    at async Object.runTests ($deno$/testing.ts:345:20)
```

Which is an improvement.

However the test still leaks async ops which means the next test fails
and the script exits and so this could still be improved further.